### PR TITLE
Fix get ID param in controller

### DIFF
--- a/Controller/Post/View.php
+++ b/Controller/Post/View.php
@@ -63,7 +63,7 @@ class View extends Action
 
     public function execute()
     {
-        $id=$this->getRequest()->getParams();
+        $id = $this->getRequest()->getParam('id');
         if ($id) {
             $trafficModel=$this->trafficFactory->create()->load($id, 'post_id');
             if ($trafficModel->getId()) {


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
$id param contains array of params instead of post ID. It might crash pages when there is added tracking data or something else after "?"
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/mageplaza/magento-2-blog/<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. 
2. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
