### PR TITLE
Bug: resaving post breaks attached image

### DIFF
--- a/Block/Adminhtml/Post/Edit/Tab/Post.php
+++ b/Block/Adminhtml/Post/Edit/Tab/Post.php
@@ -163,7 +163,20 @@ class Post extends \Magento\Backend\Block\Widget\Form\Generic implements \Magent
                 'name'  => 'image',
                 'label' => __('Image'),
                 'title' => __('Image'),
-                'note' => __('Featured image'),
+                'backend_model' => 'Magento\Config\Model\Config\Backend\Image',
+                'upload_dir' =>
+                [
+                    'config' => 'system/filesystem/media',
+                    'scope_info' => '1',
+                    'value' => 'mageplaza/blog/post/image'
+                ],
+                'base_url' =>
+                [
+                    'type' => 'media',
+                    'scope_info' => '1',
+                    'value' => 'mageplaza/blog/post/image'
+                ],
+                'note' => __('Featured image')
             ]
         );
         $fieldset->addField(

--- a/Controller/Adminhtml/Post/Save.php
+++ b/Controller/Adminhtml/Post/Save.php
@@ -46,18 +46,22 @@ class Save extends \Mageplaza\Blog\Controller\Adminhtml\Post
      * @var \Magento\Backend\Helper\Js
      */
     protected $jsHelper;
+
+    /**
+     * @var \Mageplaza\Blog\Model\TrafficFactory
+     */
     protected $trafficFactory;
 
     /**
-     * constructor
+     * Save constructor.
      *
      * @param \Mageplaza\Blog\Model\Upload $uploadModel
      * @param \Mageplaza\Blog\Model\Post\Image $imageModel
-     * @param \Magento\Backend\Model\Session $backendSession
+     * @param \Mageplaza\Blog\Model\TrafficFactory $trafficFactory
+     * @param \Magento\Backend\Model\Auth\Session $backendSession
      * @param \Magento\Backend\Helper\Js $jsHelper
      * @param \Mageplaza\Blog\Model\PostFactory $postFactory
      * @param \Magento\Framework\Registry $registry
-     * @param \Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory
      * @param \Magento\Backend\App\Action\Context $context
      */
     public function __construct(
@@ -68,7 +72,6 @@ class Save extends \Mageplaza\Blog\Controller\Adminhtml\Post
         \Magento\Backend\Helper\Js $jsHelper,
         \Mageplaza\Blog\Model\PostFactory $postFactory,
         \Magento\Framework\Registry $registry,
-        //\Magento\Backend\Model\View\Result\RedirectFactory $resultRedirectFactory,
         \Magento\Backend\App\Action\Context $context
     ) {
 
@@ -81,7 +84,7 @@ class Save extends \Mageplaza\Blog\Controller\Adminhtml\Post
     }
 
     /**
-     * run the action
+     * Run the action
      *
      * @return \Magento\Backend\Model\View\Result\Redirect
      */
@@ -92,12 +95,9 @@ class Save extends \Mageplaza\Blog\Controller\Adminhtml\Post
         $resultRedirect = $this->resultRedirectFactory->create();
         if ($data) {
             $post = $this->initPost();
-            //$post->setData($data);
 
             $image = $this->uploadModel->uploadFileAndGetName('image', $this->imageModel->getBaseDir(), $data);
             if(!empty($image) && strpos($image, self::IMAGE_UPLOAD_PATH) === false) {
-                //$post->setImage('mageplaza/blog/post/image' . $image);
-                //$post->setImage($image);
                 $data = array_merge(
                     $data,
                     [
@@ -177,7 +177,8 @@ class Save extends \Mageplaza\Blog\Controller\Adminhtml\Post
     }
 
     /**
-     * Workaround to prevent saving this data in category model and it has to be refactored in future
+     * Workaround to prevent saving this data in category model and it has to be refactored in future.
+     * Taken from magento source code:
      * @see Magento\Catalog\Controller\Adminhtml\Category\Save;
      *
      * @param array $rawData

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -21,7 +21,7 @@
  */
 -->
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="Mageplaza_Blog" setup_version="1.1.3">
+    <module name="Mageplaza_Blog" setup_version="1.1.4">
         <sequence>
             <module name="Magento_Backend"/>
         </sequence>


### PR DESCRIPTION
### Description
Changed image saving workflow (taken from magento category save)

### Fixed Issues (if relevant)
Didn't find such issue in list. 

### Manual testing scenarios
Act. result: the re-editing of the post removes picture from the post
Exp. result: the re-editing mustn't remove picture from the post
Steps to reproduce:
1. Create a post with a picture
2. Go to the Posts page in the Mageplaza tab
3. Edit the post and save the changes

### Contribution checklist
 - [ X] Pull request has a meaningful description of its purpose
 - [ X] All commits are accompanied by meaningful commit messages
 - [ O] All new or changed code is covered with unit/integration tests (if applicable)
