### PR TITLE
Update Collection.php

### DIFF
--- a/Model/ResourceModel/Comment/Grid/Collection.php
+++ b/Model/ResourceModel/Comment/Grid/Collection.php
@@ -33,10 +33,6 @@ use Psr\Log\LoggerInterface as Logger;
  */
 class Collection extends SearchResult
 {
-    /**
-     * @var string
-     */
-    public $mainTable;
 
     /**
      * Collection constructor.


### PR DESCRIPTION
### Description
Propose removing class property $mainTable, as it's not required for anything. The only thing that was required for di compilation to work properly, was to define the type for the constructor parameter $mainTable within the phpdoc ... I have already tested out di compilation with m2.2.1 without the class property $mainTable, and it works.

### Fixed Issues
1. https://github.com/mageplaza/magento-2-blog/issues/116: Blog version 2.6.0 compile error

### Manual testing scenarios
1. git checkout tags/v2.6.0
2. Edit constructor phpdoc in \Mageplaza\Blog\Model\ResourceModel\Comment\Grid\Collection so that it contains the following: `@param string $mainTable`
3. Run the following CLI command: `php bin/magento setup:di:compile`
4. Verify that di compilation is successful and does *not* produce any errors, nor fails to complete.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
