### PR TITLE
Update Sitemap.php

### DIFF
--- a/Model/Sitemap.php
+++ b/Model/Sitemap.php
@@ -21,10 +21,23 @@
 
 namespace Mageplaza\Blog\Model;
 
-use Magento\Framework\App\ObjectManager;
+use \Magento\Framework\Model\Context;
+use \Magento\Framework\Registry;
+use \Magento\Framework\Escaper;
+use \Magento\Sitemap\Helper\Data;
+use \Magento\Framework\Filesystem;
+use \Magento\Sitemap\Model\ResourceModel\Catalog\CategoryFactory;
+use \Magento\Sitemap\Model\ResourceModel\Catalog\ProductFactory;
+use \Magento\Sitemap\Model\ResourceModel\Cms\PageFactory;
+use \Magento\Framework\Stdlib\DateTime\DateTime;
+use \Magento\Store\Model\StoreManagerInterface;
+use \Magento\Framework\App\RequestInterface;
+use \Magento\Framework\Model\ResourceModel\AbstractResource;
+use \Magento\Framework\Data\Collection\AbstractDb;
+use \Magento\Config\Model\Config\Reader\Source\Deployed\DocumentRoot;
 use Magento\Framework\DataObject;
-use Mageplaza\Blog\Helper\Data;
-
+use Mageplaza\Blog\Helper\Data as BlogDataHelper;
+use Mageplaza\Blog\Helper\Image as BlogImageHelper;
 /**
  * Class Sitemap
  * @package Mageplaza\Blog\Model
@@ -35,22 +48,80 @@ class Sitemap extends \Magento\Sitemap\Model\Sitemap
      * @var \Mageplaza\Blog\Helper\Data
      */
     protected $blogDataHelper;
+
+    /**
+     * @var \Mageplaza\Blog\Helper\Image
+     */
+    protected $imageHelper;
+
     /**
      * @var mixed
      */
     protected $router;
 
     /**
-     * Initialize resource model
-     *
-     * @return void
+     * Sitemap constructor.
+     * @param Context $context
+     * @param Registry $registry
+     * @param Escaper $escaper
+     * @param Data $sitemapData
+     * @param Filesystem $filesystem
+     * @param CategoryFactory $categoryFactory
+     * @param ProductFactory $productFactory
+     * @param PageFactory $cmsFactory
+     * @param DateTime $modelDate
+     * @param StoreManagerInterface $storeManager
+     * @param RequestInterface $request
+     * @param \Magento\Framework\Stdlib\DateTime $dateTime
+     * @param BlogDataHelper $blogDataHelper
+     * @param BlogImageHelper $blogImageHelper
+     * @param AbstractResource|null $resource
+     * @param AbstractDb|null $resourceCollection
+     * @param array $data
+     * @param DocumentRoot|null $documentRoot
      */
-    protected function _construct()
-    {
-        parent::_construct();
+    public function __construct(
+        \Magento\Framework\Model\Context $context,
+        \Magento\Framework\Registry $registry,
+        \Magento\Framework\Escaper $escaper,
+        \Magento\Sitemap\Helper\Data $sitemapData,
+        \Magento\Framework\Filesystem $filesystem,
+        \Magento\Sitemap\Model\ResourceModel\Catalog\CategoryFactory $categoryFactory,
+        \Magento\Sitemap\Model\ResourceModel\Catalog\ProductFactory $productFactory,
+        \Magento\Sitemap\Model\ResourceModel\Cms\PageFactory $cmsFactory,
+        \Magento\Framework\Stdlib\DateTime\DateTime $modelDate,
+        \Magento\Store\Model\StoreManagerInterface $storeManager,
+        \Magento\Framework\App\RequestInterface $request,
+        \Magento\Framework\Stdlib\DateTime $dateTime,
+        BlogDataHelper  $blogDataHelper,
+        BlogImageHelper $blogImageHelper,
+        \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
+        \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        array $data = [],
+        DocumentRoot $documentRoot = null
+    ) {
+        $this->blogDataHelper   =   $blogDataHelper;
+        $this->imageHelper      =   $blogImageHelper;
+        $this->router           =   $this->blogDataHelper->getBlogConfig('general/url_prefix');
 
-        $this->blogDataHelper = ObjectManager::getInstance()->get(Data::class);
-        $this->router = $this->blogDataHelper->getBlogConfig('general/url_prefix');
+        parent::__construct(
+            $context,
+            $registry,
+            $escaper,
+            $sitemapData,
+            $filesystem,
+            $categoryFactory,
+            $productFactory,
+            $cmsFactory,
+            $modelDate,
+            $storeManager,
+            $request,
+            $dateTime,
+            $resource,
+            $resourceCollection,
+            $data,
+            $documentRoot
+        );
     }
 
     /**
@@ -67,8 +138,13 @@ class Sitemap extends \Magento\Sitemap\Model\Sitemap
             if (!is_null($item->getEnabled())) {
                 $images = null;
                 if ($item->getImage()) :
+                    $imageFile = $this->imageHelper->getMediaPath(
+                        $item->getImage(),
+                        \Mageplaza\Blog\Helper\Image::TEMPLATE_MEDIA_TYPE_POST
+                    );
+
                     $imagesCollection[] = new DataObject([
-                            'url' => $item->getImage(),
+                            'url' => $this->imageHelper->getMediaUrl($imageFile),
                             'caption' => null,
                         ]
                     );


### PR DESCRIPTION
Currently the sitemap generated incorrect image urls. When I submit the sitemap from a M2 store that uses the Mageplaza Magento 2 Blog, I am presented with errors related to missing images. This PR addresses that. I have already performed local testing on this multiple times, clearing cache, and verifying the generated sitemap contains the improved urls. Once I resubmit a sitemap to Google with this improved image url generation, it is accepted without any issues. This works.

### Description
1. Using proper dependency injection via php constructor injection to generate blog data/image helpers
2. Passes in the required constructor params for parent class constructor
3. Includes the image helper as a class property to assist with generating full image url paths for a generated sitemap
4. Refactors the image url generation to comply with Google image sitemap requirements: https://support.google.com/webmasters/answer/178636?hl=en
5. Changes the `<image:loc>` nodes from containing relative paths to images, to instead contain fully qualified urls

### Fixed Issues (if relevant)
Currently, image values in generated sitemap are invalid for Google sitemap format requirements.

### Manual testing scenarios
1. Pull down code
2. php bin/magento cache:flush
3. Log into admin panel
4. Go to Marketing->Sitemap
5. Generate a sitemap
6. Right-click on the sitemap link and open it in another tab.
7. Inspect the `<image:loc>` nodes and see that image urls are fully qualified

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
