### PR TITLE
Add name to design block in Layout XML

### DIFF
--- a/view/frontend/layout/mpblog_design.xml
+++ b/view/frontend/layout/mpblog_design.xml
@@ -39,7 +39,7 @@
             </container>
         </referenceContainer>
         <referenceBlock name="head.additional">
-            <block class="Mageplaza\Blog\Block\Design" template="Mageplaza_Blog::design.phtml"/>
+            <block class="Mageplaza\Blog\Block\Design" name="mpblog.design" template="Mageplaza_Blog::design.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
             <block class="Magento\Framework\View\Element\Template" name="mpblog.copy.right" after="-" template="Mageplaza_Blog::html/copyright.phtml"/>


### PR DESCRIPTION
Required for addressing/removing this block

<!--- Provide a general summary of the Pull Request in the Title above -->

Small change, adds a name to anonymous Blog\Block\Design block in layout XML
<!--- Provide a description of the changes proposed in the pull request -->

### Manual testing scenarios
1. Extend module in theme
2. Remove block in layout XML by using `<referenceBlock name="mpblog.design" remove="true">`
3. Verify that the block is gone on a blog frontend page

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages

