### PR TITLE
Fix of invalid "sidebar_left_right" values in core_config_data  after upgrade to 3.0.3 (2.5.0)

### DIFF
--- a/Setup/UpgradeData.php
+++ b/Setup/UpgradeData.php
@@ -103,11 +103,10 @@ class UpgradeData implements UpgradeDataInterface
     }
 
     /**
-     * Method maps old 'sidebar_left_right' values to 2.5.0 equivalents.
+     * Method maps old 'sidebar_left_right' values to 3.0.3 equivalents.
      * @param ModuleDataSetupInterface $setup
-     * @param ModuleContextInterface $context
      */
-    private function upgradeSidebarConstants(ModuleDataSetupInterface $setup, ModuleContextInterface $context)
+    private function upgradeSidebarConstants(ModuleDataSetupInterface $setup)
     {
         $configPath = BlogHelper::CONFIG_MODULE_PATH . '/sidebar/sidebar_left_right';
         $select = $setup->getConnection()->select()


### PR DESCRIPTION
### Description
In released version 3.0.3 (Magento 2.5.0) there are changes in Mageplaza\Blog\Model\Config\Source\SideBarLR::LEFT and Mageplaza\Blog\Model\Config\Source\SideBarLR::RIGHT constants.

After upgrading from older version the old values in core_config_data still persists and this leads to white screen (because of no layout loaded).

This pull request tries to map old values to equivalent values in the new version.

### Manual testing scenarios
1. Install version < 3.0.3
2. Upgrade to 3.0.3
3. Go to default blog page
4 WSoD

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
