### PR TITLE
Set updated_at by using Magento datetime

### DIFF
--- a/Model/ResourceModel/Author.php
+++ b/Model/ResourceModel/Author.php
@@ -24,6 +24,7 @@ namespace Mageplaza\Blog\Model\ResourceModel;
 use Magento\Framework\Model\ResourceModel\Db\AbstractDb;
 use Magento\Framework\Model\ResourceModel\Db\Context;
 use Mageplaza\Blog\Helper\Data;
+use Magento\Framework\Stdlib\DateTime\DateTime;
 
 /**
  * Class Author
@@ -42,16 +43,24 @@ class Author extends AbstractDb
     protected $_isPkAutoIncrement = false;
 
     /**
+     * @var DateTime
+     */
+    protected $date;
+
+    /**
      * Author constructor.
      * @param \Magento\Framework\Model\ResourceModel\Db\Context $context
      * @param \Mageplaza\Blog\Helper\Data $helperData
+     * @param DateTime $date
      */
     public function __construct(
         Context $context,
-        Data $helperData
+        Data $helperData,
+        DateTime $date
     )
     {
         $this->helperData = $helperData;
+        $this->date = $date;
         parent::__construct($context);
     }
 
@@ -73,7 +82,7 @@ class Author extends AbstractDb
         );
 
         if (!$object->isObjectNew()) {
-            $object->setUpdatedAt(\Zend_Date::now());
+            $object->setUpdatedAt($this->date->date());
         }
 
         return $this;


### PR DESCRIPTION
Corrects error when setting updated_at on authors

### Description
\Zend_Date::now() gives the error "DateTime::__construct(): Failed to parse time string (xx/xx/xxxx xx:xx:xx) at position 0 (2): Unexpected character" on Magento 2.3.0

### Manual testing scenarios
1. Create a new post, when creating the author for the post it will fail and throw the error above
2. Apply patch and retest

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
