### PR TITLE
Cast to string before filtering

### DIFF
--- a/Block/Frontend.php
+++ b/Block/Frontend.php
@@ -111,7 +111,7 @@ class Frontend extends Template
      */
     public function getPageFilter($content)
     {
-        return $this->filterProvider->getPageFilter()->filter($content);
+        return $this->filterProvider->getPageFilter()->filter((string) $content);
     }
 
     /**


### PR DESCRIPTION
Dear @mageplaza developers,
this pull request is created to prevent fatal errors for wrong argument types of the function `filter`.

### Description
I am just casting the variable `$content` before providing to the function `filter`. This will cast the variable `$content` to an empty string if it is `null`.

### Fixed Issues (if relevant)
For example the `afterFilter` plugin of the Magento PageBuilder expects the argument of `filter` to be a string. But in some cases is the argument `$content` in https://github.com/mageplaza/magento-2-blog/blob/v3.0.4/Block/Frontend.php#L114 not a string. A cast to a string prevents errors like the following one:
```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to Magento\\PageBuilder\\Plugin\\Filter\\TemplatePlugin::afterFilter() must be of the type string, null given, called in /var/www/html/vendor/magento/framework/Interception/Interceptor.php on line 146 and defined in /var/www/html/vendor/magento/module-page-builder/Plugin/Filter/TemplatePlugin.php:65\nStack trace:\n#0 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(146): Magento\\PageBuilder\\Plugin\\Filter\\TemplatePlugin->afterFilter(Object(Magento\\Widget\\Model\\Template\\Filter\\Interceptor), NULL, NULL)\n#1 /var/www/html/vendor/magento/framework/Interception/Interceptor.php(153): Magento\\Widget\\Model\\Template\\Filter\\Interceptor->Magento\\Framework\\Interception\\{closure}(NULL)\n#2 /var/www/html/generated/code/Magento/Widget/Model/Template/Filter/Interceptor.php(403): Magento\\Widget\\Model\\Template\\Filter\\Interceptor->___callPlugins('filter', Array, Array)\n#3 /var/www/html/vendor/mageplaza/magento-2-blog-extension/Block/Frontend.php(114): Magento\\Widget\\Model\\Template in /var/www/html/vendor/magento/module-page-builder/Plugin/Filter/TemplatePlugin.php on line 65, referer: http://127.0.0.1/index.php/blog.html
```

### Manual testing scenarios
You just need to create a after plugin that makes use of string type hints. For example the following:
```
public function afterFilter(\Magento\Framework\Filter\Template $subject, string $result) : string
{
    /** some stuff */
}
```

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)

Best Regards
Gordon