### PR TITLE
Use mb_strlen instead of strlen

### DIFF
--- a/Block/Sidebar/Search.php
+++ b/Block/Sidebar/Search.php
@@ -41,7 +41,7 @@ class Search extends Frontend
         if (!empty($posts)) {
             foreach ($posts as $item) {
                 $shortDescription = ($item->getShortDescription() && $limitDesc > 0) ? $item->getShortDescription() : '';
-                if (strlen($shortDescription) > $limitDesc) {
+                if (mb_strlen($shortDescription) > $limitDesc) {
                     $shortDescription = mb_substr($shortDescription, 0, $limitDesc, 'UTF-8') . '...';
                 }
 

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -294,8 +294,8 @@ class Post extends AbstractModel
         $shortDescription = $this->getData('short_description');
 
         $maxLength = 200;
-        if ($shorten && strlen($shortDescription) > $maxLength) {
-            $shortDescription = substr($shortDescription, 0, $maxLength) . '...';
+        if ($shorten && mb_strlen($shortDescription) > $maxLength) {
+            $shortDescription = mb_substr($shortDescription, 0, $maxLength) . '...';
         }
 
         return $shortDescription;

--- a/Ui/Component/Listing/Columns/CommentContent.php
+++ b/Ui/Component/Listing/Columns/CommentContent.php
@@ -43,7 +43,7 @@ class CommentContent extends Column
             foreach ($dataSource['data']['items'] as & $item) {
                 if (isset($item[$this->getData('name')])) {
                     $content = $item['content'];
-                    if (strlen($content) > $limitContent) {
+                    if (mb_strlen($content) > $limitContent) {
                         $content = mb_substr($content, 0, $limitContent, 'UTF-8') . '.....';
                     }
                     $item[$this->getData('name')] = '<span>' . $content . '</span>';


### PR DESCRIPTION
We faced with a strange situation.
On homepage, on recent posts, the short description was not trimmed correctly. The last character was UTF-8.

### Description
Strlen function is not save in UTF-8 content. This pull request does not have a big impact in module functionality



### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
