### PR TITLE
Added alias for Magento's Object to be compatible with PHP 7.2's rese…

### DIFF
--- a/Block/Adminhtml/Category/Edit/Tab/Post.php
+++ b/Block/Adminhtml/Category/Edit/Tab/Post.php
@@ -28,7 +28,7 @@ use Magento\Backend\Block\Widget\Grid\Extended;
 use Magento\Backend\Block\Widget\Tab\TabInterface;
 use Magento\Backend\Helper\Data;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Object;
+use Magento\Framework\Object as MObject;
 use Magento\Framework\Registry;
 use Mageplaza\Blog\Model\PostFactory;
 use Mageplaza\Blog\Model\ResourceModel\Post\Collection;
@@ -193,7 +193,7 @@ class Post extends Extended implements TabInterface
     }
 
     /**
-     * @param \Mageplaza\Blog\Model\Post|Object $item
+     * @param \Mageplaza\Blog\Model\Post|MObject $item
      *
      * @return string
      */

--- a/Block/Adminhtml/Post/Edit/Tab/Product.php
+++ b/Block/Adminhtml/Post/Edit/Tab/Product.php
@@ -29,7 +29,7 @@ use Magento\Backend\Block\Widget\Tab\TabInterface;
 use Magento\Backend\Helper\Data;
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Object;
+use Magento\Framework\Object as MObject;
 use Magento\Framework\Registry;
 use Mageplaza\Blog\Model\ResourceModel\Tag\Collection;
 use Mageplaza\Blog\Model\Tag;
@@ -179,7 +179,7 @@ class Product extends Extended implements TabInterface
     }
 
     /**
-     * @param Tag|Object $item
+     * @param Tag|MObject $item
      *
      * @return string
      */

--- a/Block/Adminhtml/Tag/Edit/Tab/Post.php
+++ b/Block/Adminhtml/Tag/Edit/Tab/Post.php
@@ -28,7 +28,7 @@ use Magento\Backend\Block\Widget\Grid\Extended;
 use Magento\Backend\Block\Widget\Tab\TabInterface;
 use Magento\Backend\Helper\Data;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Object;
+use Magento\Framework\Object as MObject;
 use Magento\Framework\Registry;
 use Mageplaza\Blog\Model\PostFactory;
 use Mageplaza\Blog\Model\ResourceModel\Post\Collection;
@@ -196,7 +196,7 @@ class Post extends Extended implements TabInterface
     }
 
     /**
-     * @param \Mageplaza\Blog\Model\Post|Object $item
+     * @param \Mageplaza\Blog\Model\Post|MObject $item
      *
      * @return string
      */

--- a/Block/Adminhtml/Topic/Edit/Tab/Post.php
+++ b/Block/Adminhtml/Topic/Edit/Tab/Post.php
@@ -28,7 +28,7 @@ use Magento\Backend\Block\Widget\Grid\Extended;
 use Magento\Backend\Block\Widget\Tab\TabInterface;
 use Magento\Backend\Helper\Data;
 use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Object;
+use Magento\Framework\Object as MObject;
 use Magento\Framework\Registry;
 use Mageplaza\Blog\Model\PostFactory;
 use Mageplaza\Blog\Model\ResourceModel\Post\Collection;
@@ -184,7 +184,7 @@ class Post extends Extended implements TabInterface
     }
 
     /**
-     * @param \Mageplaza\Blog\Model\Post|Object $item
+     * @param \Mageplaza\Blog\Model\Post|MObject $item
      *
      * @return string
      */


### PR DESCRIPTION
Added alias for Magento's Object to be compatible with PHP 7.2's reserved words.

<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This PR fixes compatibility issues with running a di compile on PHP 7.2.

When doing a bin/magento setup:di:compile on PHP 7.2, it will fail because the module made use of Magento\Framework\Object. 
However, since PHP 7.2, Object became a reserved word and can't be used. I aliased this import to temporarily fix it.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Use PHP 7.2
2. Do a setup:di:compile

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
