### PR TITLE
Replaced return type 'array' with 'int[]'

### DIFF
--- a/Api/Data/PostInterface.php
+++ b/Api/Data/PostInterface.php
@@ -405,36 +405,36 @@ interface PostInterface
     public function setLayout($layout);
 
     /**
-     * @return array|null
+     * @return int[]|null
      */
     public function getCategoryIds();
 
     /**
-     * @param array $array
+     * @param int[] $array
      *
      * @return $this
      */
     public function setCategoryIds($array);
 
     /**
-     * @return array|null
+     * @return int[]|null
      */
     public function getTagIds();
 
     /**
-     * @param array $array
+     * @param int[] $array
      *
      * @return $this
      */
     public function setTagIds($array);
 
     /**
-     * @return array|null
+     * @return int[]|null
      */
     public function getTopicIds();
 
     /**
-     * @param array $array
+     * @param int[] $array
      *
      * @return $this
      */


### PR DESCRIPTION
Return type 'array' causes issues with swagger and services.

### Description
```\Magento\Framework\Reflection\TypeProcessor``` will throw an exception on return type 'array'. To trigger that exception go to /rest/all/schema.

### Manual testing scenarios
1. Go to /rest/all/schema and validate that no exception is beeing thrown

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
