### PR TITLE
removed unnecessary index from db_schema.xml

### DIFF
--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -131,9 +131,6 @@
         <constraint xsi:type="primary" referenceId="PRIMARY">
             <column name="user_id"/>
         </constraint>
-        <index referenceId="mageplaza_blog_author" indexType="btree">
-            <column name="user_id"/>
-        </index>
     </table>
     <table name="mageplaza_blog_tag" resource="default" engine="innodb" comment="Mageplaza Blog Tag Table">
         <column xsi:type="int" name="tag_id" padding="10" unsigned="true" nullable="false" identity="true"


### PR DESCRIPTION
Removed unnecessary index from mageplaza_blog_author in db_schema.xml as when the user_id is marked as "primary" there will already be created a index.

### Description
When setting a primary key on a column the column will get a index on it already, so settings another index is just a waste of database memory.
Issue: https://github.com/mageplaza/magento-2-blog/issues/260 mentions this specific index as being the culprit behind the error message.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
