### PR TITLE
Add module prefix to template paths

### DIFF
--- a/view/frontend/layout/catalog_product_view.xml
+++ b/view/frontend/layout/catalog_product_view.xml
@@ -27,7 +27,7 @@
     </head>
     <body>
         <referenceBlock name="product.info.details">
-            <block class="Mageplaza\Blog\Block\Post\RelatedPost" name="related.post.tab" template="post/relatedpost.phtml" group="detailed_info" ifconfig="blog/product_post/product_detail/enable_post"/>
+            <block class="Mageplaza\Blog\Block\Post\RelatedPost" name="related.post.tab" template="Mageplaza_Blog::post/relatedpost.phtml" group="detailed_info" ifconfig="blog/product_post/product_detail/enable_post"/>
         </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/default.xml
+++ b/view/frontend/layout/default.xml
@@ -32,7 +32,7 @@
             </block>
         </referenceBlock>
         <referenceBlock name="footer_links">
-            <block class="Mageplaza\Blog\Block\Html\Footer" name="mp_footer_link" template="html/footer.phtml"/>
+            <block class="Mageplaza\Blog\Block\Html\Footer" name="mp_footer_link" template="Mageplaza_Blog::html/footer.phtml"/>
         </referenceBlock>
     </body>
 </page>

--- a/view/frontend/layout/mpblog_author_information.xml
+++ b/view/frontend/layout/mpblog_author_information.xml
@@ -29,7 +29,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Author\SignupForm" name="blog_edit_form" template="author/signup.phtml" cacheable="false"/>
+            <block class="Mageplaza\Blog\Block\Author\SignupForm" name="blog_edit_form" template="Mageplaza_Blog::author/signup.phtml" cacheable="false"/>
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/mpblog_author_signup.xml
+++ b/view/frontend/layout/mpblog_author_signup.xml
@@ -56,7 +56,7 @@
             </action>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Author\SignupForm" name="blog_signup_form" template="author/signup.phtml"/>
+            <block class="Mageplaza\Blog\Block\Author\SignupForm" name="blog_signup_form" template="Mageplaza_Blog::author/signup.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/mpblog_author_view.xml
+++ b/view/frontend/layout/mpblog_author_view.xml
@@ -24,10 +24,10 @@
     <update handle="mpblog_design"/>
     <body>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Author\Listpost" name="mpblog.post.list" template="post/list.phtml"/>
+            <block class="Mageplaza\Blog\Block\Author\Listpost" name="mpblog.post.list" template="Mageplaza_Blog::post/list.phtml"/>
         </referenceContainer>
         <referenceContainer name="blog.sidebar.main">
-            <block class="Mageplaza\Blog\Block\Author\Widget" after="mpblog.sidebar.mostview" name="mpblog.view.sidebar.author" template="author/widget.phtml"/>
+            <block class="Mageplaza\Blog\Block\Author\Widget" after="mpblog.sidebar.mostview" name="mpblog.view.sidebar.author" template="Mageplaza_Blog::author/widget.phtml"/>
         </referenceContainer>
         <referenceBlock name="mpblog.sidebar.category" remove="true"/>
         <referenceBlock name="mpblog.sidebar.monthly" remove="true"/>

--- a/view/frontend/layout/mpblog_design.xml
+++ b/view/frontend/layout/mpblog_design.xml
@@ -31,12 +31,12 @@
         <referenceContainer name="columns">
             <container name="div.sidebar.main" htmlTag="div" htmlClass="sidebar sidebar-main" after="main">
                 <container name="blog.sidebar.main" as="sidebar_main" label="Sidebar Main">
-                    <block class="Mageplaza\Blog\Block\Sidebar\Search" name="mpblog.sidebar.search" template="sidebar/search.phtml" ifconfig="blog/sidebar/search/enable_search"/>
-                    <block class="Mageplaza\Blog\Block\Sidebar\MostView" name="mpblog.sidebar.mostview" template="sidebar/mostview.phtml"/>
-                    <block class="Mageplaza\Blog\Block\Category\Widget" name="mpblog.sidebar.category" template="category/widget.phtml"/>
-                    <block class="Mageplaza\Blog\Block\MonthlyArchive\Widget" name="mpblog.sidebar.monthly" template="monthly/widget.phtml"/>
-                    <block class="Mageplaza\Blog\Block\Topic\Widget" name="mpblog.sidebar.topic" template="topic/widget.phtml"/>
-                    <block class="Mageplaza\Blog\Block\Tag\Widget" name="mpblog.sidebar.tag" template="tag/widget.phtml"/>
+                    <block class="Mageplaza\Blog\Block\Sidebar\Search" name="mpblog.sidebar.search" template="Mageplaza_Blog::sidebar/search.phtml" ifconfig="blog/sidebar/search/enable_search"/>
+                    <block class="Mageplaza\Blog\Block\Sidebar\MostView" name="mpblog.sidebar.mostview" template="Mageplaza_Blog::sidebar/mostview.phtml"/>
+                    <block class="Mageplaza\Blog\Block\Category\Widget" name="mpblog.sidebar.category" template="Mageplaza_Blog::category/widget.phtml"/>
+                    <block class="Mageplaza\Blog\Block\MonthlyArchive\Widget" name="mpblog.sidebar.monthly" template="Mageplaza_Blog::monthly/widget.phtml"/>
+                    <block class="Mageplaza\Blog\Block\Topic\Widget" name="mpblog.sidebar.topic" template="Mageplaza_Blog::topic/widget.phtml"/>
+                    <block class="Mageplaza\Blog\Block\Tag\Widget" name="mpblog.sidebar.tag" template="Mageplaza_Blog::tag/widget.phtml"/>
                 </container>
             </container>
         </referenceContainer>

--- a/view/frontend/layout/mpblog_post_index.xml
+++ b/view/frontend/layout/mpblog_post_index.xml
@@ -24,7 +24,7 @@
     <update handle="mpblog_design"/>
     <body>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Post\Listpost" name="mpblog.post.list" as="mpblog_post" template="post/list.phtml"/>
+            <block class="Mageplaza\Blog\Block\Post\Listpost" name="mpblog.post.list" as="mpblog_post" template="Mageplaza_Blog::post/list.phtml"/>
             <block class="Magento\Framework\View\Element\Template" name="mpblog.copy.right" after="-" template="Mageplaza_Blog::html/copyright.phtml"/>
         </referenceContainer>
     </body>

--- a/view/frontend/layout/mpblog_post_preview.xml
+++ b/view/frontend/layout/mpblog_post_preview.xml
@@ -24,10 +24,10 @@
     <update handle="mpblog_design"/>
     <body>
         <referenceBlock name="head.additional">
-            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.head" template="post/head.phtml"/>
+            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.head" template="Mageplaza_Blog::post/head.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.view" template="post/view.phtml" cacheable="false">
+            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.view" template="Mageplaza_Blog::post/view.phtml" cacheable="false">
                 <block class="Mageplaza\Blog\Block\Post\RelatedProduct" name="related.category.products" as="related_products" template="Mageplaza_Blog::product/list.phtml"/>
             </block>
         </referenceContainer>

--- a/view/frontend/layout/mpblog_post_view.xml
+++ b/view/frontend/layout/mpblog_post_view.xml
@@ -24,10 +24,10 @@
     <update handle="mpblog_design"/>
     <body>
         <referenceBlock name="head.additional">
-            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.head" template="post/head.phtml"/>
+            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.head" template="Mageplaza_Blog::post/head.phtml"/>
         </referenceBlock>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.view" template="post/view.phtml" cacheable="false">
+            <block class="Mageplaza\Blog\Block\Post\View" name="mpblog.post.view" template="Mageplaza_Blog::post/view.phtml" cacheable="false">
                 <block class="Mageplaza\Blog\Block\Post\RelatedProduct" name="related.category.products" as="related_products" template="Mageplaza_Blog::product/list.phtml"/>
             </block>
         </referenceContainer>

--- a/view/frontend/layout/mpblog_tag_view.xml
+++ b/view/frontend/layout/mpblog_tag_view.xml
@@ -24,7 +24,7 @@
     <update handle="mpblog_design"/>
     <body>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Tag\Listpost" name="mpblog.tag.post.list" template="post/list.phtml"/>
+            <block class="Mageplaza\Blog\Block\Tag\Listpost" name="mpblog.tag.post.list" template="Mageplaza_Blog::post/list.phtml"/>
         </referenceContainer>
     </body>
 </page>

--- a/view/frontend/layout/mpblog_topic_view.xml
+++ b/view/frontend/layout/mpblog_topic_view.xml
@@ -24,7 +24,7 @@
     <update handle="mpblog_design"/>
     <body>
         <referenceContainer name="content">
-            <block class="Mageplaza\Blog\Block\Topic\Listpost" name="mp.blog.topic.post.list" template="post/list.phtml"/>
+            <block class="Mageplaza\Blog\Block\Topic\Listpost" name="mp.blog.topic.post.list" template="Mageplaza_Blog::post/list.phtml"/>
         </referenceContainer>
     </body>
 </page>


### PR DESCRIPTION
This PR adds the `Mageplaza_Blog::` module prefix to template paths in layout files. This fixes an issue where the templates cannot be found if the block class is overridden.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
