### PR TITLE
Make sens : select products according post id

### DIFF
--- a/Block/Adminhtml/Post/Edit/Tab/Product.php
+++ b/Block/Adminhtml/Post/Edit/Tab/Product.php
@@ -109,7 +109,7 @@ class Product extends Extended implements TabInterface
             ['mp_p' => $collection->getTable('mageplaza_blog_post_product')],
             'e.entity_id = mp_p.entity_id',
             ['position']
-        );
+        )->where('mp_p.post_id=' . $this->getPost()->getId());
 
         $this->setCollection($collection);
 


### PR DESCRIPTION
If no where on post_id and product is set for multiple post, its make a duplicate ID on backend when trying to edit post.
So please, it's make sens to select on post_id when editing a post and retrieve its affected products.

### Description
If sames products are set on multiple post, its make an error type : duplicated entity ID when selecting in the product collection.

### Fixed Issues (if relevant)
Add where condition in the collection select.
