### PR TITLE
Add full page cache support to post listings

### DIFF
--- a/Block/Listpost.php
+++ b/Block/Listpost.php
@@ -22,17 +22,19 @@
 namespace Mageplaza\Blog\Block;
 
 use Exception;
+use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Phrase;
 use Magento\Theme\Block\Html\Pager;
 use Mageplaza\Blog\Model\Config\Source\DisplayType;
+use Mageplaza\Blog\Model\Post;
 use Mageplaza\Blog\Model\ResourceModel\Post\Collection;
 
 /**
  * Class Listpost
  * @package Mageplaza\Blog\Block\Post
  */
-class Listpost extends Frontend
+class Listpost extends Frontend implements IdentityInterface
 {
     /**
      * @return Collection
@@ -208,5 +210,12 @@ class Listpost extends Frontend
         }
 
         return $pageTitle;
+    }
+
+    public function getIdentities()
+    {
+        return [
+            Post::CACHE_TAG
+        ];
     }
 }

--- a/Model/Post.php
+++ b/Model/Post.php
@@ -23,6 +23,7 @@ namespace Mageplaza\Blog\Model;
 
 use Magento\Catalog\Model\ResourceModel\Product\CollectionFactory as ProductCollectionFactory;
 use Magento\Framework\Data\Collection\AbstractDb;
+use Magento\Framework\DataObject\IdentityInterface;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Framework\Model\AbstractModel;
 use Magento\Framework\Model\Context;
@@ -94,7 +95,7 @@ use Mageplaza\Blog\Model\ResourceModel\Topic\CollectionFactory as TopicCollectio
  * @method array getTopicsIds()
  * @method Post setTopicsIds(array $topicIds)
  */
-class Post extends AbstractModel
+class Post extends AbstractModel implements IdentityInterface
 {
     /**
      * Cache tag
@@ -319,7 +320,10 @@ class Post extends AbstractModel
      */
     public function getIdentities()
     {
-        return [self::CACHE_TAG . '_' . $this->getId()];
+        return [
+            self::CACHE_TAG,
+            self::CACHE_TAG . '_' . $this->getId()
+        ];
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->

Magento gathers all identities from blocks and adds them to the X-Magento-Tags header for the page. 
By adding the post cache tag to the post list identities, pages cached to the full page cache 
containing post lists are cleared from the full page cache when any post is saved in Magento.

Additionally fixed a bug where the post model didn't implement the identity interface.
Without implementing the interface, Magento is not aware that the post model has identities.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Load a post list in frontend, make sure it is loaded from full page cache.
2. Create a new post in Magento admin and save it.
3. Load the post list again. It should be cleared from full page cache and show the updated list with the new post.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
