### PR TITLE
Update Sitemap.php to fix issue #295

### DIFF
--- a/Model/Sitemap.php
+++ b/Model/Sitemap.php
@@ -86,7 +86,7 @@ class Sitemap extends \Magento\Sitemap\Model\Sitemap
                         'url' => $this->imageHelper->getMediaUrl($imageFile),
                         'caption' => null,
                     ]);
-                    $images = new DataObject(['collection' => $imagesCollection]);
+                    $images = new DataObject(['collection' => $imagesCollection, 'title' => $item->getName()]);
                 }
                 $postSiteMapCollection[$item->getId()] = new DataObject([
                     'id' => $item->getId(),


### PR DESCRIPTION
### Description
Add the title to the images so the sitemap generation works

### Fixed Issues (if relevant)
1. https://github.com/mageplaza/magento-2-blog/issues/295 : Sitemap generation fails because of missing image info

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Create sitemap
2. 

### Contribution checklist
 - [ /] Pull request has a meaningful description of its purpose
 - [ /] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
