### PR TITLE
Wrong setter method name for author customer id in author data interface

### DIFF
--- a/Api/Data/AuthorInterface.php
+++ b/Api/Data/AuthorInterface.php
@@ -152,7 +152,7 @@ interface AuthorInterface
      *
      * @return $this
      */
-    public function setCustomerIdId($id);
+    public function setCustomerId($id);
 
     /**
      * @return int|null


### PR DESCRIPTION
Hi,
The setter method have wrong name so third party apis can't create author and after calling getCustomerId the customer_id is null