### PR TITLE
Remove special "mixed" class name

### DIFF
--- a/Model/ResourceModel/Category/Collection.php
+++ b/Model/ResourceModel/Category/Collection.php
@@ -25,7 +25,6 @@ use Magento\Eav\Model\Entity\Attribute;
 use Magento\Framework\Data\Collection\AbstractDb;
 use Magento\Framework\DB\Select;
 use Magento\Sales\Model\ResourceModel\Collection\AbstractCollection;
-use Magento\Tests\NamingConvention\true\mixed;
 use Mageplaza\Blog\Api\Data\SearchResult\CategorySearchResultInterface;
 use Mageplaza\Blog\Model\Category;
 use Mageplaza\Blog\Model\ResourceModel\Category as CategoryResourceModel;


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This fixes DI compile issues when running on php 8.1
```
Fatal error: Cannot use Magento\Tests\NamingConvention\true\mixed as mixed because 'mixed' is a special class name in vendor/mageplaza/magento-2-blog-extension/Model/ResourceModel/Category/Collection.php on line 28
```
### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
