### PR TITLE
 Use the null coalescing operator to default the value to an empty st…

### DIFF
--- a/Model/Category.php
+++ b/Model/Category.php
@@ -192,7 +192,7 @@ class Category extends AbstractModel
     {
         $ids = $this->getData('path_ids');
         if ($ids === null) {
-            $ids = explode('/', $this->getPath());
+            $ids = explode('/', $this->getPath() ?? '');
             $this->setData('path_ids', $ids);
         }
 


### PR DESCRIPTION
[php 8.1 - explode(): Passing null to parameter] 
this happened on Category Model line 195 
fixed by adding null coalescing operator to default the value to an empty string if the value is null 