### PR TITLE
fix issue 307

### DIFF
--- a/Block/Adminhtml/Post/Edit/Tab/Product.php
+++ b/Block/Adminhtml/Post/Edit/Tab/Product.php
@@ -111,7 +111,7 @@ class Product extends Extended implements TabInterface
             ['mp_p' => $collection->getTable('mageplaza_blog_post_product')],
             'e.entity_id = mp_p.entity_id',
             ['position']
-        )->distinct(true);
+        )->group('e.entity_id');
 
         $this->setCollection($collection);
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

Fix issue when having the same product in different Posts with different positions.

### Description
Magento's `->distinct(true)` only relates to the category_product_entity entry and does not distinct the multiple `position` values from `mageplaza_blog_post_products`. Grouping the query instead alleviates the issue completely.

### Fixed Issues (if relevant)
https://github.com/mageplaza/magento-2-blog/issues/307

### Manual testing scenarios
1.  Have at least two different posts
2.  Set Product X in post A and set position 1 to Product X in post A. Set product X in post B and set position 0 to product X in post B. 
3. You will notice an error about duplicated values inside a collection, a critical issue.
4. Changing the proposed line removes only the single product line from the SQL query.
