### PR TITLE
Allow Saving Duplicate URL Key On Different Store Views

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -669,6 +669,12 @@ class Data extends CoreHelper
 
         if ($id = $object->getId()) {
             $select->where($resource->getIdFieldName() . ' != :object_id');
+            $storeIds = $object->getStoreIds();
+            if (!empty($storeIds)) {
+                foreach (explode(',', $storeIds) ?? [] as $store) {
+                    $select->where("FIND_IN_SET(${store}, store_ids)");
+                }
+            }
             $binds['object_id'] = (int)$id;
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description
<!--- Provide a description of the changes proposed in the pull request -->
This allows the blog post with the same URL to be customized in multiple store views. For example, a user can add a post's translated version without changing the URL key for each locale.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. In a multistore environment, create a post with a specific URL and assign it to (store 1).
2. Duplicate the post, change its content, assign it to (store 2), and set the URL to the previous value.
3. The post should be visible on both store views with the same URL key but different content.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
