### PR TITLE
Adjust URL name validation

### DIFF
--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -69,7 +69,7 @@
                 </field>
                 <field id="url_prefix" translate="label" type="text" sortOrder="15" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>Route Name</label>
-                    <validate>validate-alphanum</validate>
+                    <validate>required-entry no-whitespace</validate>
                 </field>
                 <field id="url_suffix" translate="label comment" type="text" sortOrder="16" showInDefault="1" showInWebsite="1" showInStore="1" canRestore="1">
                     <label>URL Suffix</label>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->

### Description:

The issue is we can't update the Route Name for the blog page with dashes like this photo:
![image](https://github.com/mageplaza/magento-2-blog/assets/20222239/397096ed-6e10-4419-84eb-8203a2e7d3c9)

So the issue was in the validation for this field it's allowed only letters and numbers.
-----
### Fix:
Changed the validation logic for Route Name input to allow using dashes.


Thanks,
Abdulrahman.

