### PR TITLE
Reinsert SEO fields in Blog Post Edit Form

### DIFF
--- a/Block/Adminhtml/Post/Edit/Tab/Post.php
+++ b/Block/Adminhtml/Post/Edit/Tab/Post.php
@@ -303,6 +303,33 @@ class Post extends Generic implements TabInterface
         );
         $this->_eventManager->dispatch('after_adminhtml_blog_post_info_tab', ['fieldset' => $fieldset]);
 
+        $seoFieldset = $form->addFieldset('seo_fieldset', [
+            'legend' => __('Search Engine Optimization'),
+            'class' => 'fieldset-wide'
+        ]);
+
+        $seoFieldset->addField('meta_title', 'text', [
+            'name' => 'meta_title',
+            'label' => __('Meta Title'),
+            'title' => __('Meta Title')
+        ]);
+        $seoFieldset->addField('meta_description', 'textarea', [
+            'name' => 'meta_description',
+            'label' => __('Meta Description'),
+            'title' => __('Meta Description')
+        ]);
+        $seoFieldset->addField('meta_keywords', 'textarea', [
+            'name' => 'meta_keywords',
+            'label' => __('Meta Keywords'),
+            'title' => __('Meta Keywords')
+        ]);
+        $seoFieldset->addField('meta_robots', 'select', [
+            'name' => 'meta_robots',
+            'label' => __('Meta Robots'),
+            'title' => __('Meta Robots'),
+            'values' => $this->metaRobotsOptions->toOptionArray()
+        ]);
+
         $designFieldset = $form->addFieldset('design_fieldset', [
             'legend' => __('Design'),
             'class'  => 'fieldset-wide'
@@ -317,7 +344,11 @@ class Post extends Generic implements TabInterface
 
         if (!$post->getId()) {
             $post->addData([
-                'allow_comment' => 1
+                'allow_comment' => 1,
+                'meta_title' => $this->_scopeConfig->getValue('blog/seo/meta_title'),
+                'meta_description' => $this->_scopeConfig->getValue('blog/seo/meta_description'),
+                'meta_keywords' => $this->_scopeConfig->getValue('blog/seo/meta_keywords'),
+                'meta_robots' => $this->_scopeConfig->getValue('blog/seo/meta_robots'),
             ]);
         }
 

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -12,6 +12,10 @@
     <column xsi:type="varchar" name="url_key" nullable="true" length="255" comment="Post URL Key"/>
     <column xsi:type="int" name="in_rss" padding="11" unsigned="false" nullable="true" identity="false" comment="Post In RSS"/>
     <column xsi:type="int" name="allow_comment" padding="11" unsigned="false" nullable="true" identity="false" comment="Post Allow Comment"/>
+    <column xsi:type="varchar" name="meta_title" nullable="true" length="255" comment="Meta Title"/>
+    <column xsi:type="mediumtext" name="meta_keywords" nullable="true" comment="Meta Keywords"/>
+    <column xsi:type="mediumtext" name="meta_description" nullable="true" comment="Meta Description"/>
+    <column xsi:type="mediumtext" name="meta_robots" nullable="true" comment="Post Meta Robots"/>
     <column xsi:type="timestamp" name="updated_at" on_update="false" nullable="true"/>
     <column xsi:type="timestamp" name="created_at" on_update="false" nullable="true"/>
     <column xsi:type="int" name="author_id" padding="10" unsigned="true" nullable="true" identity="false" comment="Author ID"/>


### PR DESCRIPTION
<!--- Provide a general summary of the Pull Request in the Title above -->
### Description
- The structure maintains logic to map specific SEO to blog posts but the fields were not present in the db_schema or in the admin form
<!--- Provide a description of the changes proposed in the pull request -->


![META_2](https://github.com/mageplaza/magento-2-blog/assets/160128878/7c66b340-653a-4d08-9745-bce6ef478e3e)





