### PR TITLE
Tag & Author HTML links to render correctly

### DIFF
--- a/view/frontend/templates/post/info/author.phtml
+++ b/view/frontend/templates/post/info/author.phtml
@@ -36,17 +36,19 @@ $modifierName = $modifier !== null ? $modifier->getName() : '';
 <?php if ($authorName && $helper->showAuthorInfo()) : ?>
     |
     <span><i class="fa fa-user">&nbsp;</i>
-                            <?= $escaper->escapeHtml(__(
-                                'By: %1',
-                                '<a class="mp-info" href="' . $author->getUrl() . '">' . $authorName . '</a>'
-                            )) ?></span>
+        <?= /* @noEscape */ __(
+            'By: %1',
+            '<a class="mp-info" href="' . $escaper->escapeUrl($author->getUrl()) . '">' . $escaper->escapeHtml($authorName) . '</a>'
+        ) ?>
+    </span>
     <?php if ($authorName != $modifierName && $modifierName) : ?>
         |
         <span><i class="fa fa-edit">&nbsp;</i>
-                                <?= $escaper->escapeHtml(__(
-                                    'Modify By: %1 at %2',
-                                    '<a class="mp-info" href="' . $modifier->getUrl() . '">' . $modifierName . '</a>',
-                                    $block->getDateFormat($_post->getUpdatedAt())
-                                )) ?></span>
+            <?= /* @noEscape */ __(
+                'Modify By: %1 at %2',
+                '<a class="mp-info" href="' . $escaper->escapeUrl($modifier->getUrl()) . '">' . $escaper->escapeHtml($modifierName) . '</a>',
+                $block->getDateFormat($_post->getUpdatedAt())
+            ) ?>
+        </span>
     <?php endif; ?>
 <?php endif; ?>

--- a/view/frontend/templates/post/info/author.phtml
+++ b/view/frontend/templates/post/info/author.phtml
@@ -37,16 +37,18 @@ $modifierName = $modifier !== null ? $modifier->getName() : '';
     |
     <span><i class="fa fa-user">&nbsp;</i>
         <?= /* @noEscape */ __(
-            'By: %1',
-            '<a class="mp-info" href="' . $escaper->escapeUrl($author->getUrl()) . '">' . $escaper->escapeHtml($authorName) . '</a>'
+            'By: <a class="mp-info" href="%1">%2</a>',
+            $escaper->escapeUrl($author->getUrl()),
+            $authorName
         ) ?>
     </span>
     <?php if ($authorName != $modifierName && $modifierName) : ?>
         |
         <span><i class="fa fa-edit">&nbsp;</i>
             <?= /* @noEscape */ __(
-                'Modify By: %1 at %2',
-                '<a class="mp-info" href="' . $escaper->escapeUrl($modifier->getUrl()) . '">' . $escaper->escapeHtml($modifierName) . '</a>',
+                'Modify By: <a class="mp-info" href="%1">%2</a> at %3',
+                $escaper->escapeUrl($modifier->getUrl()),
+                $modifierName,
                 $block->getDateFormat($_post->getUpdatedAt())
             ) ?>
         </span>

--- a/view/frontend/templates/post/info/tag.phtml
+++ b/view/frontend/templates/post/info/tag.phtml
@@ -29,5 +29,5 @@ use Magento\Framework\Escaper;
 $_post = $block->getPost();
 ?>
 <?php if ($tagList = $block->getTagList($_post)) : ?>
-    | <span><i class="fa fa-tags"></i><?= __('Tags: ') ?><?= $tagList ?></span>
+    | <span><i class="fa fa-tags"></i><?= $escaper->escapeHtml(__('Tags: ')) ?><?= /* @noEscape */ $tagList ?></span>
 <?php endif; ?>

--- a/view/frontend/templates/post/info/tag.phtml
+++ b/view/frontend/templates/post/info/tag.phtml
@@ -29,5 +29,5 @@ use Magento\Framework\Escaper;
 $_post = $block->getPost();
 ?>
 <?php if ($tagList = $block->getTagList($_post)) : ?>
-    | <span><i class="fa fa-tags"></i><?= $escaper->escapeHtml(__('Tags: %1', $tagList)); ?></span>
+    | <span><i class="fa fa-tags"></i><?= __('Tags: ') ?><?= $tagList ?></span>
 <?php endif; ?>


### PR DESCRIPTION
tags & author HTML links do not render correctly. To display properly - modify the PHP code to output the tags without escaping the HTML

<!--- Provide a general summary of the Pull Request in the Title above -->
<img width="997" alt="Screenshot 2025-02-01 145448" src="https://github.com/user-attachments/assets/1c9c9c83-3100-481c-b32e-f83b2c23311c" />

### Description
Tags not displaying properly on desktop related to how the tags are being rendered. Snippet shows that the tags are being output using the following line:
php
<?= $escaper->escapeHtml(__('Tags: %1', $tagList)); ?>

This line is escaping the HTML content of the tags, which is causing the tags to be displayed as plain text instead of clickable links on the desktop view.

To fix this issue, we modified the PHP code to output the tags without escaping the HTML:

php
<?php if ($tagList = $block->getTagList($_post)) : ?>
    | <span><i class="fa fa-tags"></i><?= __('Tags: ') ?><?= $tagList ?></span>
<?php endif; ?>

This allows the HTML structure of the tags to be preserved, resulting in clickable tag links similar to what is shown in the search results for the mobile view.

<img width="1006" alt="Screenshot 2025-02-01 145615" src="https://github.com/user-attachments/assets/e3b21f99-7b18-4a09-a6c1-10c6541f500c" />